### PR TITLE
Refactoring ideas proposals

### DIFF
--- a/examples/dbpedia.js
+++ b/examples/dbpedia.js
@@ -1,5 +1,5 @@
 const namespace = require('@rdfjs/namespace')
-const clownfaceIo = require('..')
+const clownface = require('..')
 
 const ns = {
   dbp: namespace('http://dbpedia.org/property/'),
@@ -9,15 +9,16 @@ const ns = {
 
 async function main () {
   try {
-    const eiffelTowerLink = clownfaceIo().namedNode(ns.dbr('Eiffel_Tower'))
-    const eiffelTower = await eiffelTowerLink.fetch()
+    const eiffelTowerLink = clownface.io().namedNode(ns.dbr('Eiffel_Tower'))
+    const request = eiffelTowerLink.fetch()
+    const eiffelTower = await request.successful
 
     console.log(eiffelTower.term.value)
     console.log(eiffelTower.dataset.size)
     console.log(eiffelTower.out().terms.length)
 
     const mainContractorLink = eiffelTower.out(ns.dbp.mainContractor)
-    const mainContractor = await mainContractorLink.fetch()
+    const mainContractor = await mainContractorLink.fetch().successful
 
     console.log(mainContractor.out(ns.foaf.name).value)
   } catch (err) {

--- a/examples/dbpedia.js
+++ b/examples/dbpedia.js
@@ -9,7 +9,7 @@ const ns = {
 
 async function main () {
   try {
-    const eiffelTowerLink = clownface.io().namedNode(ns.dbr('Eiffel_Tower'))
+    const eiffelTowerLink = clownface().namedNode(ns.dbr('Eiffel_Tower'))
     const eiffelTower = await eiffelTowerLink.fetch()
 
     console.log(eiffelTower.term.value)

--- a/examples/dbpedia.js
+++ b/examples/dbpedia.js
@@ -10,15 +10,14 @@ const ns = {
 async function main () {
   try {
     const eiffelTowerLink = clownface.io().namedNode(ns.dbr('Eiffel_Tower'))
-    const request = eiffelTowerLink.fetch()
-    const eiffelTower = await request.successful
+    const eiffelTower = await eiffelTowerLink.fetch()
 
     console.log(eiffelTower.term.value)
     console.log(eiffelTower.dataset.size)
     console.log(eiffelTower.out().terms.length)
 
     const mainContractorLink = eiffelTower.out(ns.dbp.mainContractor)
-    const mainContractor = await mainContractorLink.fetch().successful
+    const mainContractor = await mainContractorLink.fetch()
 
     console.log(mainContractor.out(ns.foaf.name).value)
   } catch (err) {

--- a/examples/full-control.js
+++ b/examples/full-control.js
@@ -11,7 +11,7 @@ const clownface = setup({
   rdfFetch,
   fetch: nodeifyFetch,
   clownface: realClownface,
-  formats,
+  formats
 })
 
 const ns = {

--- a/examples/full-control.js
+++ b/examples/full-control.js
@@ -1,0 +1,35 @@
+const formats = require('@rdfjs/formats-common')
+const rdf = require('@rdfjs/dataset')
+const rdfFetch = require('@rdfjs/fetch-lite')
+const namespace = require('@rdfjs/namespace')
+const nodeifyFetch = require('nodeify-fetch')
+const realClownface = require('clownface')
+const setup = require('../factory')
+
+const clownface = setup({
+  factory: rdf,
+  rdfFetch,
+  fetch: nodeifyFetch,
+  clownface: realClownface,
+  formats,
+})
+
+const ns = {
+  dbp: namespace('http://dbpedia.org/property/'),
+  dbr: namespace('http://dbpedia.org/resource/'),
+  foaf: namespace('http://xmlns.com/foaf/0.1/')
+}
+
+async function main () {
+  try {
+    const eiffelTowerLink = clownface().namedNode(ns.dbr('Eiffel_Tower'))
+    const eiffelTower = await eiffelTowerLink.fetch()
+
+    console.log(eiffelTower.term.value)
+    console.log(eiffelTower.dataset.size)
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+main()

--- a/examples/handling-failed.js
+++ b/examples/handling-failed.js
@@ -1,7 +1,7 @@
 const namespace = require('@rdfjs/namespace')
 const clownface = require('clownface')
 const rdf = require('rdf-ext')
-const io = require('..')
+const { io } = require('..')
 
 const ns = {
   rdfs: namespace('http://www.w3.org/2000/01/rdf-schema#')
@@ -18,7 +18,7 @@ async function main () {
       rdf.namedNode('http://zazuko.github.com/foo-bar') // Not found
     ])
 
-  const seeAlsoLinks = io.io(graph).out(ns.rdfs.seeAlso)
+  const seeAlsoLinks = io(graph).out(ns.rdfs.seeAlso)
   const request = seeAlsoLinks.fetch()
   const resources = await request
 

--- a/examples/handling-failed.js
+++ b/examples/handling-failed.js
@@ -1,7 +1,7 @@
 const namespace = require('@rdfjs/namespace')
 const clownface = require('clownface')
 const rdf = require('rdf-ext')
-const { io } = require('..')
+const { wrap } = require('..')
 
 const ns = {
   rdfs: namespace('http://www.w3.org/2000/01/rdf-schema#')
@@ -18,7 +18,7 @@ async function main () {
       rdf.namedNode('http://zazuko.github.com/foo-bar') // Not found
     ])
 
-  const seeAlsoLinks = io(graph).out(ns.rdfs.seeAlso)
+  const seeAlsoLinks = wrap(graph).out(ns.rdfs.seeAlso)
   const request = seeAlsoLinks.fetch()
   const resources = await request
 

--- a/examples/handling-failed.js
+++ b/examples/handling-failed.js
@@ -1,0 +1,35 @@
+const namespace = require('@rdfjs/namespace')
+const clownface = require('clownface')
+const rdf = require('rdf-ext')
+const io = require('..')
+
+const ns = {
+  rdfs: namespace('http://www.w3.org/2000/01/rdf-schema#')
+}
+
+async function main () {
+  const graph = clownface({ dataset: rdf.dataset() })
+    .blankNode()
+    .addOut(ns.rdfs.seeAlso, [
+      rdf.namedNode('http://dbpedia.org/resource/Eiffel_Tower'),
+      rdf.namedNode('http://dbpedia.org/resource/London_Bridge'),
+      rdf.namedNode('http://dbpedia.ork/resource/Eiffel_Tower'), // bogus domain
+      rdf.namedNode('http://google.com'), // non-RDF resource
+      rdf.namedNode('http://zazuko.github.com/foo-bar') // Not found
+    ])
+
+  const seeAlsoLinks = io.io(graph).out(ns.rdfs.seeAlso)
+  const request = seeAlsoLinks.fetch()
+  const resources = await request
+
+  // awaited request acts just like graph pointer
+  console.log(`Received ${resources.values.length} resources: ${resources.out(ns.rdfs.label, { language: 'en' }).values}`)
+
+  // any failures are a TermMap returned by the failures property
+  const failedRequests = await request.failures
+  ;[...failedRequests.entries()].forEach(([term, { error }]) => {
+    console.log(`${term.value} failed because ${error.message}`)
+  })
+}
+
+main()

--- a/examples/handling-failed.js
+++ b/examples/handling-failed.js
@@ -19,14 +19,13 @@ async function main () {
     ])
 
   const seeAlsoLinks = wrap(graph).out(ns.rdfs.seeAlso)
-  const request = seeAlsoLinks.fetch()
-  const resources = await request
+  const fetched = await seeAlsoLinks.fetch()
 
   // awaited request acts just like graph pointer
-  console.log(`Received ${resources.values.length} resources: ${resources.out(ns.rdfs.label, { language: 'en' }).values}`)
+  console.log(`Received ${fetched.values.length} resources: ${fetched.out(ns.rdfs.label, { language: 'en' }).values}`)
 
   // any failures are a TermMap returned by the failures property
-  const failedRequests = await request.failures
+  const failedRequests = fetched.failures
   ;[...failedRequests.entries()].forEach(([term, { error }]) => {
     console.log(`${term.value} failed because ${error.message}`)
   })

--- a/examples/tbbt-file.js
+++ b/examples/tbbt-file.js
@@ -2,7 +2,7 @@ const clownface = require('..')
 
 async function main () {
   try {
-    const tbbtLink = clownface.io().namedNode(`file:${__dirname}/../node_modules/tbbt-ld/dist/tbbt.nq`)
+    const tbbtLink = clownface().namedNode(`file:${__dirname}/../node_modules/tbbt-ld/dist/tbbt.nq`)
     const tbbt = await tbbtLink.fetch()
     const amy = tbbt.namedNode('http://localhost:8080/data/person/amy-farrah-fowler')
 

--- a/examples/tbbt-file.js
+++ b/examples/tbbt-file.js
@@ -1,9 +1,9 @@
-const clownfaceIo = require('..')
+const clownface = require('..')
 
 async function main () {
   try {
-    const tbbtLink = clownfaceIo().namedNode('file:node_modules/tbbt-ld/dist/tbbt.nq')
-    const tbbt = await tbbtLink.fetch()
+    const tbbtLink = clownface.io().namedNode(`file:${__dirname}/../node_modules/tbbt-ld/dist/tbbt.nq`)
+    const tbbt = await tbbtLink.fetch().successful
     const amy = tbbt.namedNode('http://localhost:8080/data/person/amy-farrah-fowler')
 
     console.log(amy.term.value)

--- a/examples/tbbt-file.js
+++ b/examples/tbbt-file.js
@@ -3,7 +3,7 @@ const clownface = require('..')
 async function main () {
   try {
     const tbbtLink = clownface.io().namedNode(`file:${__dirname}/../node_modules/tbbt-ld/dist/tbbt.nq`)
-    const tbbt = await tbbtLink.fetch().successful
+    const tbbt = await tbbtLink.fetch()
     const amy = tbbt.namedNode('http://localhost:8080/data/person/amy-farrah-fowler')
 
     console.log(amy.term.value)

--- a/examples/tbbt.js
+++ b/examples/tbbt.js
@@ -2,7 +2,7 @@ const clownface = require('..')
 
 async function main () {
   try {
-    const tbbtLink = clownface.io().namedNode('https://zazuko.github.io/tbbt-ld/dist/tbbt.nq')
+    const tbbtLink = clownface().namedNode('https://zazuko.github.io/tbbt-ld/dist/tbbt.nq')
     const tbbt = await tbbtLink.fetch()
     const amy = tbbt.namedNode('http://localhost:8080/data/person/amy-farrah-fowler')
 

--- a/examples/tbbt.js
+++ b/examples/tbbt.js
@@ -3,7 +3,7 @@ const clownface = require('..')
 async function main () {
   try {
     const tbbtLink = clownface.io().namedNode('https://zazuko.github.io/tbbt-ld/dist/tbbt.nq')
-    const tbbt = await tbbtLink.fetch().successful
+    const tbbt = await tbbtLink.fetch()
     const amy = tbbt.namedNode('http://localhost:8080/data/person/amy-farrah-fowler')
 
     console.log(amy.term.value)

--- a/examples/tbbt.js
+++ b/examples/tbbt.js
@@ -1,9 +1,9 @@
-const clownfaceIo = require('..')
+const clownface = require('..')
 
 async function main () {
   try {
-    const tbbtLink = clownfaceIo().namedNode('https://zazuko.github.io/tbbt-ld/dist/tbbt.nq')
-    const tbbt = await tbbtLink.fetch()
+    const tbbtLink = clownface.io().namedNode('https://zazuko.github.io/tbbt-ld/dist/tbbt.nq')
+    const tbbt = await tbbtLink.fetch().successful
     const amy = tbbt.namedNode('http://localhost:8080/data/person/amy-farrah-fowler')
 
     console.log(amy.term.value)

--- a/factory.js
+++ b/factory.js
@@ -1,11 +1,13 @@
 const { createHandler } = require('./lib/proxy')
 const wrapFetch = require('./lib/fetch')
 
-module.exports = ({ factory, datasetFactory, rdfFetch, fetch, clownface }) => {
+module.exports = ({ factory, rdfFetch, fetch, clownface }) => {
+  const rdf = factory
+
   function wrap(pointer) {
     return new Proxy(pointer, createHandler(wrapFetch(rdfFetch, fetch), factory))
   }
-  function io ({ dataset = datasetFactory(), graph, term, value, factory, _context } = {}) {
+  function io ({ dataset = rdf.dataset(), graph, term, value, factory = rdf, _context } = {}) {
     return wrap(clownface({ dataset, graph, term, value, factory, _context }))
   }
 

--- a/factory.js
+++ b/factory.js
@@ -8,5 +8,7 @@ module.exports = ({ factory, datasetFactory, fetch, clownface }) => {
     return wrap(clownface({ dataset, graph, term, value, factory, _context }))
   }
 
-  return { io, wrap }
+  io.wrap = wrap
+
+  return io
 }

--- a/factory.js
+++ b/factory.js
@@ -4,7 +4,7 @@ const wrapFetch = require('./lib/fetch')
 module.exports = ({ factory, rdfFetch, fetch, formats, clownface }) => {
   const rdf = factory
 
-  function wrap(pointer) {
+  function wrap (pointer) {
     return new Proxy(pointer, createHandler(wrapFetch(rdfFetch, fetch, formats), factory))
   }
   function io ({ dataset = rdf.dataset(), graph, term, value, factory = rdf, _context } = {}) {

--- a/factory.js
+++ b/factory.js
@@ -1,8 +1,9 @@
 const { createHandler } = require('./lib/proxy')
+const wrapFetch = require('./lib/fetch')
 
-module.exports = ({ factory, datasetFactory, fetch, clownface }) => {
+module.exports = ({ factory, datasetFactory, rdfFetch, fetch, clownface }) => {
   function wrap(pointer) {
-    return new Proxy(pointer, createHandler(fetch, factory))
+    return new Proxy(pointer, createHandler(wrapFetch(rdfFetch, fetch), factory))
   }
   function io ({ dataset = datasetFactory(), graph, term, value, factory, _context } = {}) {
     return wrap(clownface({ dataset, graph, term, value, factory, _context }))

--- a/factory.js
+++ b/factory.js
@@ -1,0 +1,10 @@
+const { createHandler } = require('./lib/proxy')
+
+module.exports = ({ factory, datasetFactory, fetch, clownface }) => ({
+  wrap(pointer) {
+    return new Proxy(pointer, createHandler(fetch, factory))
+  },
+  io ({ dataset = datasetFactory(), graph, term, value, factory, _context } = {}) {
+    return this.wrap(clownface({ dataset, graph, term, value, factory, _context }))
+  }
+})

--- a/factory.js
+++ b/factory.js
@@ -1,10 +1,12 @@
 const { createHandler } = require('./lib/proxy')
 
-module.exports = ({ factory, datasetFactory, fetch, clownface }) => ({
-  wrap(pointer) {
+module.exports = ({ factory, datasetFactory, fetch, clownface }) => {
+  function wrap(pointer) {
     return new Proxy(pointer, createHandler(fetch, factory))
-  },
-  io ({ dataset = datasetFactory(), graph, term, value, factory, _context } = {}) {
-    return this.wrap(clownface({ dataset, graph, term, value, factory, _context }))
   }
-})
+  function io ({ dataset = datasetFactory(), graph, term, value, factory, _context } = {}) {
+    return wrap(clownface({ dataset, graph, term, value, factory, _context }))
+  }
+
+  return { io, wrap }
+}

--- a/factory.js
+++ b/factory.js
@@ -1,11 +1,11 @@
 const { createHandler } = require('./lib/proxy')
 const wrapFetch = require('./lib/fetch')
 
-module.exports = ({ factory, rdfFetch, fetch, clownface }) => {
+module.exports = ({ factory, rdfFetch, fetch, formats, clownface }) => {
   const rdf = factory
 
   function wrap(pointer) {
-    return new Proxy(pointer, createHandler(wrapFetch(rdfFetch, fetch), factory))
+    return new Proxy(pointer, createHandler(wrapFetch(rdfFetch, fetch, formats), factory))
   }
   function io ({ dataset = rdf.dataset(), graph, term, value, factory = rdf, _context } = {}) {
     return wrap(clownface({ dataset, graph, term, value, factory, _context }))

--- a/index.js
+++ b/index.js
@@ -4,4 +4,4 @@ const rdfFetch = require('@rdfjs/fetch')
 const fetch = require('./lib/rawFetch')
 const factory = require('./factory')
 
-module.exports = factory({ datasetFactory: rdf.dataset, factory: rdf, rdfFetch, fetch, clownface })
+module.exports = factory({ factory: rdf, rdfFetch, fetch, clownface })

--- a/index.js
+++ b/index.js
@@ -1,17 +1,6 @@
 const clownface = require('clownface')
 const rdf = require('rdf-ext')
 const fetch = require('./lib/fetch')
-const { clownfaceIoHandler } = require('./lib/proxy')
+const factory = require('./factory')
 
-function wrap (pointer) {
-  return new Proxy(pointer, clownfaceIoHandler(fetch))
-}
-
-function factory ({ dataset = rdf.dataset(), graph, term, value, factory = rdf, _context } = {}) {
-  return wrap(clownface({ dataset, graph, term, value, factory, _context }))
-}
-
-module.exports = {
-  io: factory,
-  wrap,
-}
+module.exports = factory({ datasetFactory: rdf.dataset, factory: rdf, fetch, clownface })

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const clownface = require('clownface')
 const rdf = require('rdf-ext')
-const fetch = require('./lib/fetch')
+const rdfFetch = require('@rdfjs/fetch')
+const fetch = require('./lib/rawFetch')
 const factory = require('./factory')
 
-module.exports = factory({ datasetFactory: rdf.dataset, factory: rdf, fetch, clownface })
+module.exports = factory({ datasetFactory: rdf.dataset, factory: rdf, rdfFetch, fetch, clownface })

--- a/index.js
+++ b/index.js
@@ -1,24 +1,17 @@
-const toArray= require('clownface/lib/toArray')
-const Clownface = require('clownface/lib/Clownface')
+const clownface = require('clownface')
 const rdf = require('rdf-ext')
 const fetch = require('./lib/fetch')
+const { clownfaceIoHandler } = require('./lib/proxy')
 
-class ClownfaceIo extends Clownface {
-  constructor ({ dataset = rdf.dataset(), graph, term, value, factory = rdf, _context }) {
-    super({ dataset, graph, term, value, factory, _context })
-
-    super.constructor.fromContext = context => {
-      return new this.constructor({ _context: toArray(context), factory: context.factory })
-    }
-  }
-
-  fetch (options) {
-    return fetch.call(this, options)
-  }
+function wrap (pointer) {
+  return new Proxy(pointer, clownfaceIoHandler(fetch))
 }
 
-function factory ({ dataset, graph, term, value, factory, _context } = {}) {
-  return new ClownfaceIo({ dataset, graph, term, value, factory, _context })
+function factory ({ dataset = rdf.dataset(), graph, term, value, factory = rdf, _context } = {}) {
+  return wrap(clownface({ dataset, graph, term, value, factory, _context }))
 }
 
-module.exports = factory
+module.exports = {
+  io: factory,
+  wrap,
+}

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -5,17 +5,6 @@ const TermMap = require('@rdfjs/term-map')
 const rawFetch = require('./rawFetch')
 const { createHandler } = require('./proxy')
 
-function checkResponse (res) {
-  if (res.ok) {
-    return
-  }
-
-  const err = new Error(res.statusText)
-  err.status = res.status
-
-  throw err
-}
-
 class ClownfaceIoRequest extends Promise {
   constructor (executor, fetches, factory, namespace) {
     super(executor)

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -1,8 +1,6 @@
 const Context = require('clownface/lib/Context')
 const clownface = require('clownface')
-const rdfFetch = require('@rdfjs/fetch')
 const TermMap = require('@rdfjs/term-map')
-const rawFetch = require('./rawFetch')
 const { createHandler } = require('./proxy')
 
 class ClownfaceIoRequest extends Promise {
@@ -26,7 +24,7 @@ class ClownfaceIoRequest extends Promise {
   }
 }
 
-function fetch (options = {}) {
+const wrapFetch = (rdfFetch, rawFetch) => function (options = {}) {
   const fetches = this.terms.map(async term => {
     let response = null
     try {
@@ -61,10 +59,10 @@ function fetch (options = {}) {
         })
       }))
 
-    resolve(new Proxy(clownface({_context}), createHandler(fetch, this.__factory)))
+    resolve(new Proxy(clownface({_context}), createHandler(wrapFetch(rdfFetch, rawFetch), this.__factory)))
   }
 
   return new ClownfaceIoRequest(executor, fetches, this.factory, this.namespace)
 }
 
-module.exports = fetch
+module.exports = wrapFetch

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -3,7 +3,7 @@ const clownface = require('clownface')
 const rdfFetch = require('@rdfjs/fetch')
 const TermMap = require('@rdfjs/term-map')
 const rawFetch = require('./rawFetch')
-const { clownfaceIoHandler } = require('./proxy')
+const { createHandler } = require('./proxy')
 
 function checkResponse (res) {
   if (res.ok) {
@@ -16,41 +16,21 @@ function checkResponse (res) {
   throw err
 }
 
-class ClownfaceIoRequest {
-  constructor (fetches, factory, namespace) {
+class ClownfaceIoRequest extends Promise {
+  constructor (executor, fetches, factory, namespace) {
+    super(executor)
     this.__fetches = fetches
     this.__factory = factory
     this.__namespace = namespace
   }
 
-  get successful() {
+  get failures() {
     return (async () => {
       const results = await Promise.all(this.__fetches)
+      const failed = await Promise.all(results.filter(([, { error }]) => error))
 
-      const _context = await Promise.all(results.filter(([r]) => r.ok)
-        .map(async ([res, term]) => {
-          const dataset = await res.dataset()
-
-          return new Context({
-            dataset,
-            // graph,
-            value: term,
-            factory: this.__factory,
-            namespace: this.__namespace
-          })
-        }))
-
-      return new Proxy(clownface({_context}), clownfaceIoHandler(fetch))
-    })()
-  }
-
-  get failed() {
-    return (async () => {
-      const results = await Promise.all(this.__fetches)
-      const failed = await Promise.all(results.filter(([r]) => !r.ok))
-
-      return failed.reduce((map, [res, term]) => {
-        map.set(term, res)
+      return failed.reduce((map, [term, value]) => {
+        map.set(term, value)
         return map
       }, new TermMap())
     })()
@@ -58,17 +38,44 @@ class ClownfaceIoRequest {
 }
 
 function fetch (options = {}) {
-  return new ClownfaceIoRequest(this.terms.map(async term => {
+  const fetches = this.terms.map(async term => {
+    let response = null
     try {
-      return [await rdfFetch(term.value, {
+      response = await rdfFetch(term.value, {
         factory: this.factory,
         fetch: rawFetch,
         ...options
-      }), term]
+      })
+
+      if (!response.ok) {
+        return [term, { response, error: new Error(response.statusText) }]
+      }
+
+      return [term, { response, dataset: await response.dataset() }]
     } catch(error) {
-      return [{ ok: false, error }, term]
+      return [term, { response, error }]
     }
-  }), this.factory, this.namespace)
+  })
+
+  async function executor (resolve) {
+    const responses = await Promise.all(fetches)
+
+    const _context = await Promise.all(responses
+      .filter(([, {error}]) => !error)
+      .map(async ([term, { dataset }]) => {
+        return new Context({
+          dataset,
+          // graph,
+          value: term,
+          factory: this.__factory,
+          namespace: this.__namespace
+        })
+      }))
+
+    resolve(new Proxy(clownface({_context}), createHandler(fetch, this.__factory)))
+  }
+
+  return new ClownfaceIoRequest(executor, fetches, this.factory, this.namespace)
 }
 
 module.exports = fetch

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -1,6 +1,9 @@
 const Context = require('clownface/lib/Context')
+const clownface = require('clownface')
 const rdfFetch = require('@rdfjs/fetch')
+const TermMap = require('@rdfjs/term-map')
 const rawFetch = require('./rawFetch')
+const { clownfaceIoHandler } = require('./proxy')
 
 function checkResponse (res) {
   if (res.ok) {
@@ -13,28 +16,59 @@ function checkResponse (res) {
   throw err
 }
 
-async function fetch (options = {}) {
-  const context = await Promise.all(this.terms.map(async term => {
-    const res = await rdfFetch(term.value, {
-      factory: this.factory,
-      fetch: rawFetch,
-      ...options
-    })
+class ClownfaceIoRequest {
+  constructor (fetches, factory, namespace) {
+    this.__fetches = fetches
+    this.__factory = factory
+    this.__namespace = namespace
+  }
 
-    checkResponse(res)
+  get successful() {
+    return (async () => {
+      const results = await Promise.all(this.__fetches)
 
-    const dataset = await res.dataset()
+      const _context = await Promise.all(results.filter(([r]) => r.ok)
+        .map(async ([res, term]) => {
+          const dataset = await res.dataset()
 
-    return new Context({
-      dataset,
-      // graph,
-      value: term,
-      factory: this.factory,
-      namespace: this.namespace
-    })
-  }))
+          return new Context({
+            dataset,
+            // graph,
+            value: term,
+            factory: this.__factory,
+            namespace: this.__namespace
+          })
+        }))
 
-  return new this.constructor({ _context: context })
+      return new Proxy(clownface({_context}), clownfaceIoHandler(fetch))
+    })()
+  }
+
+  get failed() {
+    return (async () => {
+      const results = await Promise.all(this.__fetches)
+      const failed = await Promise.all(results.filter(([r]) => !r.ok))
+
+      return failed.reduce((map, [res, term]) => {
+        map.set(term, res)
+        return map
+      }, new TermMap())
+    })()
+  }
+}
+
+function fetch (options = {}) {
+  return new ClownfaceIoRequest(this.terms.map(async term => {
+    try {
+      return [await rdfFetch(term.value, {
+        factory: this.factory,
+        fetch: rawFetch,
+        ...options
+      }), term]
+    } catch(error) {
+      return [{ ok: false, error }, term]
+    }
+  }), this.factory, this.namespace)
 }
 
 module.exports = fetch

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -24,13 +24,14 @@ class ClownfaceIoRequest extends Promise {
   }
 }
 
-const wrapFetch = (rdfFetch, rawFetch) => function (options = {}) {
+const wrapFetch = (rdfFetch, rawFetch, formats) => function (options = {}) {
   const fetches = this.terms.map(async term => {
     let response = null
     try {
       response = await rdfFetch(term.value, {
         factory: this.factory,
         fetch: rawFetch,
+        formats,
         ...options
       })
 

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -3,28 +3,7 @@ const clownface = require('clownface')
 const TermMap = require('@rdfjs/term-map')
 const { createHandler } = require('./proxy')
 
-class ClownfaceIoRequest extends Promise {
-  constructor (executor, fetches, factory, namespace) {
-    super(executor)
-    this.__fetches = fetches
-    this.__factory = factory
-    this.__namespace = namespace
-  }
-
-  get failures() {
-    return (async () => {
-      const results = await Promise.all(this.__fetches)
-      const failed = await Promise.all(results.filter(([, { error }]) => error))
-
-      return failed.reduce((map, [term, value]) => {
-        map.set(term, value)
-        return map
-      }, new TermMap())
-    })()
-  }
-}
-
-const wrapFetch = (rdfFetch, rawFetch, formats) => function (options = {}) {
+const wrapFetch = (rdfFetch, rawFetch, formats) => async function (options = {}) {
   const fetches = this.terms.map(async term => {
     let response = null
     try {
@@ -40,30 +19,35 @@ const wrapFetch = (rdfFetch, rawFetch, formats) => function (options = {}) {
       }
 
       return [term, { response, dataset: await response.dataset() }]
-    } catch(error) {
+    } catch (error) {
       return [term, { response, error }]
     }
   })
 
-  async function executor (resolve) {
-    const responses = await Promise.all(fetches)
+  const responses = await Promise.all(await Promise.all(fetches))
+  const failures = responses
+    .filter(([, { error }]) => error)
+    .reduce((map, [term, value]) => {
+      map.set(term, value)
+      return map
+    }, new TermMap())
 
-    const _context = await Promise.all(responses
-      .filter(([, {error}]) => !error)
-      .map(async ([term, { dataset }]) => {
-        return new Context({
-          dataset,
-          // graph,
-          value: term,
-          factory: this.__factory,
-          namespace: this.__namespace
-        })
-      }))
+  const _context = responses
+    .filter(([, { error }]) => !error)
+    .map(([term, { dataset }]) => {
+      return new Context({
+        dataset,
+        // graph,
+        value: term,
+        factory: this.__factory,
+        namespace: this.__namespace
+      })
+    })
 
-    resolve(new Proxy(clownface({_context}), createHandler(wrapFetch(rdfFetch, rawFetch), this.__factory)))
-  }
+  const pointer = clownface({ _context })
+  const handler = createHandler(wrapFetch(rdfFetch, rawFetch), this.__factory, failures)
 
-  return new ClownfaceIoRequest(executor, fetches, this.factory, this.namespace)
+  return new Proxy(pointer, handler)
 }
 
 module.exports = wrapFetch

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -1,0 +1,30 @@
+const Clownface = require('clownface/lib/Clownface')
+const rdf = require('rdf-ext')
+
+const clownfaceIoHandler = fetch => ({
+  get(target, name) {
+    if (name === 'fetch') {
+      return (options) => fetch.call(target, options)
+    }
+
+    if (typeof target[name] === 'function') {
+      return new Proxy(target[name], {
+        apply(targetFunc, that, args) {
+          const result = targetFunc.call(that, ...args)
+          if (result instanceof Clownface) {
+            result.factory = rdf
+            return new Proxy(result, clownfaceIoHandler(fetch))
+          }
+
+          return result
+        }
+      })
+    }
+
+    return target[name]
+  },
+})
+
+module.exports = {
+  clownfaceIoHandler
+}

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -1,14 +1,18 @@
 const Clownface = require('clownface/lib/Clownface')
 
-const createHandler = (fetch, factory) => ({
-  get(target, name) {
+const createHandler = (fetch, factory, failures) => ({
+  get (target, name) {
     if (name === 'fetch') {
       return (options) => fetch.call(target, options)
     }
 
+    if (name === 'failures') {
+      return failures
+    }
+
     if (typeof target[name] === 'function') {
       return new Proxy(target[name], {
-        apply(targetFunc, that, args) {
+        apply (targetFunc, that, args) {
           const result = targetFunc.call(that, ...args)
           if (result instanceof Clownface) {
             result.factory = factory
@@ -21,7 +25,7 @@ const createHandler = (fetch, factory) => ({
     }
 
     return target[name]
-  },
+  }
 })
 
 module.exports = {

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -1,7 +1,6 @@
 const Clownface = require('clownface/lib/Clownface')
-const rdf = require('rdf-ext')
 
-const clownfaceIoHandler = fetch => ({
+const createHandler = (fetch, factory) => ({
   get(target, name) {
     if (name === 'fetch') {
       return (options) => fetch.call(target, options)
@@ -12,8 +11,8 @@ const clownfaceIoHandler = fetch => ({
         apply(targetFunc, that, args) {
           const result = targetFunc.call(that, ...args)
           if (result instanceof Clownface) {
-            result.factory = rdf
-            return new Proxy(result, clownfaceIoHandler(fetch))
+            result.factory = factory
+            return new Proxy(result, createHandler(fetch, factory))
           }
 
           return result
@@ -26,5 +25,5 @@ const clownfaceIoHandler = fetch => ({
 })
 
 module.exports = {
-  clownfaceIoHandler
+  createHandler
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "homepage": "https://github.com/zazuko/clownface-io",
   "dependencies": {
     "@rdfjs/fetch": "^2.0.0",
+    "@rdfjs/term-map": "^1.0.0",
     "clownface": "^1.0.0",
     "file-fetch": "^1.4.1",
     "proto-fetch": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@rdfjs/term-map": "^1.0.0",
     "clownface": "^1.0.0",
     "file-fetch": "^1.4.1",
+    "nodeify-fetch": "^2.2.1",
     "proto-fetch": "^1.0.0",
     "rdf-ext": "^1.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
   },
   "devDependencies": {
     "@rdfjs/namespace": "^1.1.0",
+    "@rdfjs/dataset": "^1.0.1",
+    "@rdfjs/formats-common": "^2.1.0",
+    "@rdfjs/fetch-lite": "^2.1.0",
     "tbbt-ld": "^1.1.0"
   }
 }


### PR DESCRIPTION
As discussed here are my ideas for the clownface/io library

### Composition over inheritance. This way an existing graph pointer can be "fetch-enabled"

```js
const cf = require('clownface')
const { wrap } = require('clownface-io')

let pointer = cf({ dataset, term })

pointer = wrap(pointer)

const also = await pointer.out(rdf.seeAlso).fetch()
```

### Add a response wrapper object, which allows for accessing individual failed responses and errors

```js
const cf = require('clownface')
const { io } = require('clownface-io')

const request = io({ dataset, term }).fetch()

const failedRequests = await request.failures
```

### Decoupled from `rdf-ext` and `fetch`

In browser one could compose their own using native fetch and swapping the `clownface` factory and RDF/JS factories

```js
import clownface from 'clownface'
import factory from 'clownface-io/factory'
import * as rdf from '@rdfjs/data-model'
import dataset from 'rdf-dataset-indexed'

const { io } = factory({
  fetch, 
  clownface, 
  datasetFactory: dataset,
  factory: rdf
})
```